### PR TITLE
Add VSCode config to automatically run lint on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "editor.codeActionsOnSave": {
+        "source.fixAll": true
+    },
+    "python.linting.enabled": true,
+    "python.linting.flake8Enabled": true,
+    "python.linting.lintOnSave": true
+}

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -7,7 +7,8 @@
         "python.linting.pylintEnabled": true,
         "python.formatting.autopep8Path": "/usr/local/bin/autopep8",
         "python.formatting.blackPath": "/usr/local/bin/black",
-        "python.formatting.yapfPath": "/usr/local/bin/yapf"
+        "python.formatting.yapfPath": "/usr/local/bin/yapf",
+        "python.linting.flake8Enabled": true
     },
     "extensions": [
         "ms-python.python",


### PR DESCRIPTION
Add VSCode configuration to automatically run lint on save.

* Modify `devcontainer.json` to enable `flake8` linting.
* Add `.vscode/settings.json` with configurations to run lint on save and enable `flake8` linting.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Justin2997/via-rail-notif?shareId=b456a4c6-2ebc-488f-865b-b8ac52b0b361).